### PR TITLE
Fix indexing bug in `releasedata_06` which reported wrong release button

### DIFF
--- a/ctmouse.asm
+++ b/ctmouse.asm
@@ -2716,7 +2716,7 @@ releasedata_06	proc
 		mov	[_ARG_AX_],ax
 		xor	ax,ax
 
-		inc	bx
+		inc	bx			; bx is {0, 1, 2, 3}
 		mov	si,TSRdref:wheel
 		jz	@@retlastpos		; jump if BX was -1
 		mov	si,cx
@@ -2729,7 +2729,8 @@ releasedata_06	proc
 ; ERRIF (6 ne size BUTTLASTSTATE) "BUTTLASTSTATE structure size changed!"
 		add	bx,bx
 		add	si,bx			; SI+BX=buttrelease
-		add	bx,bx			;  +button*size BUTTLASTSTATE
+		add	bx,bx			; bx is {0, 3, 6, 9}
+		add	bx,bx			;  +button*size BUTTLASTSTATE {0, 6, 12, 18}
 
 @@retlastpos:	xchg	[si + bx + offset BUTTLASTSTATE.counter],ax
 		mov	cx,[si+bx + offset BUTTLASTSTATE.lastcol]


### PR DESCRIPTION
How to reproduce
----------------
Use this version of ctmouse, with a serial microsoft protocol mouse (no wheel) in COM1, start it with `ctmouse /S1`.
In Monkey Island 1 or 2:
- Hover mouse over an active object that can be "Looked at" (e.g. the governor's poster on the first screen of Monkey Island 1).
- Push Left mouse button without releasing, this triggers "Walk to poster"
- Relase Left mouse button. This triggers the right-click "Look at" verb, instead of "Walk to". This suggests that release button data is wrong.

Explanation of the fix
----------------------
The bug seems to be in the int33,6 routine `releasedata_06`. Register `bx` is the button number:
0 for Left, 1 for Right, 2 for Middle, and -1 for Wheel. Within the function `bx` gets incremented so its values are: 0 for Wheel, 1 for Left, 2 for Right, and 3 for Middle. Register `bx` is used to index array `buttrelease` each element of which is BUTTLASTSTATE size long, which is 6 bytes.
So we would expect the values of `bx` to be {0, 6, 9, 12} but instead they are {0, 3, 6, 9}.

This seems to fix the issue, though I am not sure how the original code worked. The original build of ctmouse does not have this issue.